### PR TITLE
Created Text file note export

### DIFF
--- a/Core/ExtensionClasses/StringExtension.cs
+++ b/Core/ExtensionClasses/StringExtension.cs
@@ -1,0 +1,16 @@
+
+namespace Core.ExtensionClasses
+{
+    public static class StringExtensions
+    {
+        public static string Repeat(this string str, int times)
+        {
+            string newString = str;
+            for (int i = 0; i < times-1; i++)
+            {
+                newString += str;
+            }
+            return newString;
+        }
+    }
+}

--- a/Core/Interfaces/IDocumentType.cs
+++ b/Core/Interfaces/IDocumentType.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using Core.Objects;
+
+namespace Core.Interfaces
+{
+    public interface IDocumentType
+    {
+        List<Note> Note {get;set;}
+        void Export(string filePath);
+        string ConvertNote(Note note);
+        string ConvertTitle(string title);
+        string ConvertTags(List<NoteTag> noteTags);
+        string ConvertContent(string content);
+    }
+}

--- a/Core/Interfaces/IDocumentType.cs
+++ b/Core/Interfaces/IDocumentType.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Collections.Generic;
 using Core.Objects;
 
@@ -5,8 +6,10 @@ namespace Core.Interfaces
 {
     public interface IDocumentType
     {
-        List<Note> Note {get;set;}
-        void Export(string filePath);
+        List<Note> Notes {get;set;}
+        string FileExtension {get;}
+        void Export(Stream stream);
+        string ConvertNotes();
         string ConvertNote(Note note);
         string ConvertTitle(string title);
         string ConvertTags(List<NoteTag> noteTags);

--- a/Core/Objects/DocumentTypes/DocxDocument.cs
+++ b/Core/Objects/DocumentTypes/DocxDocument.cs
@@ -1,11 +1,14 @@
 using System.Collections.Generic;
+using System.IO;
 using Core.Interfaces;
 
 namespace Core.Objects.DocumentTypes
 {
     public class DocxDocument : IDocumentType
     {
-        public List<Note> Note { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public List<Note> Notes { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+
+        public string FileExtension => ".docx";
 
         public string ConvertContent(string content)
         {
@@ -13,6 +16,11 @@ namespace Core.Objects.DocumentTypes
         }
 
         public string ConvertNote(Note note)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public string ConvertNotes()
         {
             throw new System.NotImplementedException();
         }
@@ -27,9 +35,9 @@ namespace Core.Objects.DocumentTypes
             throw new System.NotImplementedException();
         }
 
-        public void Export(string filePath)
+        public void Export(Stream stream)
         {
-            
+            throw new System.NotImplementedException();
         }
     }
 }

--- a/Core/Objects/DocumentTypes/DocxDocument.cs
+++ b/Core/Objects/DocumentTypes/DocxDocument.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using Core.Interfaces;
+
+namespace Core.Objects.DocumentTypes
+{
+    public class DocxDocument : IDocumentType
+    {
+        public List<Note> Note { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+
+        public string ConvertContent(string content)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public string ConvertNote(Note note)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public string ConvertTags(List<NoteTag> noteTags)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public string ConvertTitle(string title)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void Export(string filePath)
+        {
+            
+        }
+    }
+}

--- a/Core/Objects/DocumentTypes/LatexDocument.cs
+++ b/Core/Objects/DocumentTypes/LatexDocument.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using Core.Interfaces;
+
+namespace Core.Objects.DocumentTypes
+{
+    public class LatexDocument : IDocumentType
+    {
+        public List<Note> Note { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+
+        public string ConvertContent(string content)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public string ConvertNote(Note note)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public string ConvertTags(List<NoteTag> noteTags)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public string ConvertTitle(string title)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void Export(string filePath)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/Core/Objects/DocumentTypes/LatexDocument.cs
+++ b/Core/Objects/DocumentTypes/LatexDocument.cs
@@ -1,11 +1,14 @@
 using System.Collections.Generic;
+using System.IO;
 using Core.Interfaces;
 
 namespace Core.Objects.DocumentTypes
 {
     public class LatexDocument : IDocumentType
     {
-        public List<Note> Note { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public List<Note> Notes { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+
+        public string FileExtension => ".tex";
 
         public string ConvertContent(string content)
         {
@@ -13,6 +16,11 @@ namespace Core.Objects.DocumentTypes
         }
 
         public string ConvertNote(Note note)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public string ConvertNotes()
         {
             throw new System.NotImplementedException();
         }
@@ -27,7 +35,7 @@ namespace Core.Objects.DocumentTypes
             throw new System.NotImplementedException();
         }
 
-        public void Export(string filePath)
+        public void Export(Stream stream)
         {
             throw new System.NotImplementedException();
         }

--- a/Core/Objects/DocumentTypes/TxtDocument.cs
+++ b/Core/Objects/DocumentTypes/TxtDocument.cs
@@ -20,7 +20,7 @@ namespace Core.Objects.DocumentTypes
 
         public string ConvertContent(string content)
         {
-            return $"Content:{Environment.NewLine}{content}";
+            return $"Content:{Environment.NewLine}{content}{Environment.NewLine.Repeat(2)}";
         }
 
         public string ConvertNotes()

--- a/Core/Objects/DocumentTypes/TxtDocument.cs
+++ b/Core/Objects/DocumentTypes/TxtDocument.cs
@@ -1,0 +1,51 @@
+using System;
+using Core.Interfaces;
+using Core.ExtensionClasses;
+using System.Collections.Generic;
+
+namespace Core.Objects.DocumentTypes
+{
+    public class TxtDocument : IDocumentType
+    {
+        public List<Note> Note { get; set; }
+
+        public TxtDocument(List<Note> notes)
+        {
+            
+        }
+
+        public string ConvertContent(string content)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string ConvertNote(Note note)
+        {
+            string convertedNote = "";
+
+            convertedNote += ConvertTitle(note.Name);
+
+
+            return convertedNote;
+        }
+
+        public string ConvertTags(List<NoteTag> noteTags)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string ConvertTitle(string title)
+        {
+            string convertedNote = "";
+            convertedNote += "#".Repeat(4+title.Length) + Environment.NewLine;
+            convertedNote += $"# {title} #" + Environment.NewLine;
+            convertedNote += "#".Repeat(4+title.Length) + Environment.NewLine;
+            return convertedNote;
+        }
+
+        public void Export(string filePath)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/Core/Objects/DocumentTypes/TxtDocument.cs
+++ b/Core/Objects/DocumentTypes/TxtDocument.cs
@@ -2,50 +2,55 @@ using System;
 using Core.Interfaces;
 using Core.ExtensionClasses;
 using System.Collections.Generic;
+using System.Linq;
+using System.IO;
 
 namespace Core.Objects.DocumentTypes
 {
     public class TxtDocument : IDocumentType
     {
-        public List<Note> Note { get; set; }
+        public List<Note> Notes { get; set; }
+
+        public string FileExtension => ".txt";
 
         public TxtDocument(List<Note> notes)
         {
-            
+            Notes = notes;
         }
 
         public string ConvertContent(string content)
         {
-            throw new NotImplementedException();
+            return $"Content:{Environment.NewLine}{content}";
         }
 
-        public string ConvertNote(Note note)
+        public string ConvertNotes()
         {
-            string convertedNote = "";
-
-            convertedNote += ConvertTitle(note.Name);
-
-
-            return convertedNote;
+            return string.Join("", Notes.Select(note => ConvertNote(note)));
         }
 
         public string ConvertTags(List<NoteTag> noteTags)
         {
-            throw new NotImplementedException();
+            return $"Tags: {string.Join(", ", noteTags.Select(noteTag => noteTag.Tag.Name))}{Environment.NewLine.Repeat(3)}";
         }
 
         public string ConvertTitle(string title)
         {
-            string convertedNote = "";
-            convertedNote += "#".Repeat(4+title.Length) + Environment.NewLine;
-            convertedNote += $"# {title} #" + Environment.NewLine;
-            convertedNote += "#".Repeat(4+title.Length) + Environment.NewLine;
-            return convertedNote;
+            return $"{"#".Repeat(4 + title.Length)}{Environment.NewLine}# {title} #{Environment.NewLine}{"#".Repeat(4 + title.Length)}{Environment.NewLine}";
         }
 
-        public void Export(string filePath)
+
+
+        public string ConvertNote(Note note)
         {
-            throw new System.NotImplementedException();
+            return $"{ConvertTitle(note.Name)}{ConvertTags(note.NoteTags)}{ConvertContent(note.Content)}";
+        }
+
+        public void Export(Stream stream)
+        {
+            using (StreamWriter writer = new StreamWriter(stream))
+            {
+                writer.Write(ConvertNotes());
+            }
         }
     }
 }

--- a/Core/Objects/Tag.cs
+++ b/Core/Objects/Tag.cs
@@ -7,6 +7,6 @@ namespace Core.Objects
     {
         public int Key {get;set;}
         public string Name {get;set;}
-        public List<NoteTag> NoteTags {get;set;}
+        public List<NoteTag> NoteTags {get;set;} = new List<NoteTag>();
     }
 }

--- a/FrontEnd/AssemblyInfo.cs
+++ b/FrontEnd/AssemblyInfo.cs
@@ -1,10 +1,1 @@
-using System.Windows;
-
-[assembly:ThemeInfo(
-    ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
-                                     //(used if a resource is not found in the page,
-                                     // or application resource dictionaries)
-    ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
-                                              //(used if a resource is not found in the page,
-                                              // app, or any theme specific resource dictionaries)
-)]
+[assembly: System.Windows.ThemeInfo(System.Windows.ResourceDictionaryLocation.None, System.Windows.ResourceDictionaryLocation.SourceAssembly)]

--- a/FrontEnd/MainWindow.xaml.cs
+++ b/FrontEnd/MainWindow.xaml.cs
@@ -22,6 +22,7 @@ using Core.Objects;
 using Core.SqlHelper;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Internal;
+using Core.ExtensionClasses;
 
 namespace FrontEnd
 {
@@ -562,19 +563,6 @@ namespace FrontEnd
 
             NoteContentBox.FontFamily = new FontFamily(configuration.AppSettings.Settings["DefaultFont"].Value);
             tabsize = byte.Parse(configuration.AppSettings.Settings["TabSize"].Value);
-        }
-    }
-
-    public static class Extensions
-    {
-        public static string Repeat(this string str, int times)
-        {
-            string newString = str;
-            for (int i = 0; i < times; i++)
-            {
-                newString += str;
-            }
-            return newString;
         }
     }
 }

--- a/FrontEnd/MainWindow.xaml.cs
+++ b/FrontEnd/MainWindow.xaml.cs
@@ -558,7 +558,7 @@ namespace FrontEnd
 
         private void SettingsButton_Click(object sender, RoutedEventArgs e)
         {
-            SettingsWindow sw = new SettingsWindow(configuration);
+            SettingsWindow sw = new SettingsWindow(configuration, context);
             sw.ShowDialog();
 
             NoteContentBox.FontFamily = new FontFamily(configuration.AppSettings.Settings["DefaultFont"].Value);

--- a/FrontEnd/SettingsWindow.xaml
+++ b/FrontEnd/SettingsWindow.xaml
@@ -3,7 +3,6 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:emoji="clr-namespace:Emoji.Wpf;assembly=Emoji.Wpf"
         xmlns:local="clr-namespace:FrontEnd"
         mc:Ignorable="d"
         Title="SettingsWindow" Height="450" Width="800" SizeToContent="WidthAndHeight">
@@ -21,7 +20,6 @@
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition/>
         </Grid.ColumnDefinitions>
-        <emoji:TextBlock Grid.Column="0" Grid.Row="0" Text="✒ Font Face" Margin="3"/>
         <ComboBox Grid.Column="1" Grid.Row="0"  Margin="3" MinWidth="250" x:Name="FontPicker" SelectedValuePath="Content">
             <ComboBoxItem Content="Consolas"/>
             <ComboBoxItem Content="Courier New"/>
@@ -29,14 +27,28 @@
             <ComboBoxItem Content="DejaVu Sans Mono"/>
             <ComboBoxItem Content="Times New Roman"/>
         </ComboBox>
+        <StackPanel VerticalAlignment="Center" Orientation="Horizontal" Grid.Column="0" Grid.Row="0" Margin="5">
+            <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE8D2;" VerticalAlignment="Center" FontSize="20"/>
+            <TextBlock Text="Preferred Font Family" Margin="10 0" />
+        </StackPanel>
+        <StackPanel VerticalAlignment="Center" Orientation="Horizontal" Grid.Column="0" Grid.Row="1" Margin="5">
+            <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xF785;" VerticalAlignment="Center" FontSize="20"/>
+            <TextBlock Text="Use dev channel" Margin="10 0" />
+        </StackPanel>
 
-        <emoji:TextBlock Text="💻 Use dev channel" Grid.Column="0" Grid.Row="1" Margin="3"/>
         <CheckBox Margin="3" Grid.Column="1" Grid.Row="1" x:Name="DevCheck"/>
 
-        <emoji:TextBlock Text="↔ Use space instead of tab" Grid.Column="0" Grid.Row="2" Margin="3"/>
+        <StackPanel VerticalAlignment="Center" Orientation="Horizontal" Grid.Column="0" Grid.Row="2" Margin="5">
+            <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE7FD;" VerticalAlignment="Center" FontSize="20"/>
+            <TextBlock Text="Use space instead of tab" Margin="10 0" />
+        </StackPanel>
         <CheckBox Margin="3" Grid.Column="1" Grid.Row="2" x:Name="TabCheck"/>
+        <StackPanel VerticalAlignment="Center" Orientation="Horizontal" Grid.Column="0" Grid.Row="3" Margin="5">
+            <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xEA62;" VerticalAlignment="Center" FontSize="20"/>
+            <TextBlock Text="Tab size" Margin="10 0" />
+        </StackPanel>
 
-        <emoji:TextBlock Grid.Column="0" Grid.Row="3" Text="⏩ Tab size" Margin="3"/>
+
         <ComboBox Grid.Column="1" Grid.Row="3"  Margin="3" MinWidth="250" x:Name="TabSizePicker" SelectedValuePath="Content">
             <ComboBoxItem Content="1"/>
             <ComboBoxItem Content="2"/>
@@ -47,9 +59,23 @@
             <ComboBoxItem Content="7"/>
             <ComboBoxItem Content="8"/>
         </ComboBox>
+        <StackPanel VerticalAlignment="Center" Orientation="Horizontal" Grid.Column="0" Grid.Row="4" Margin="5">
+            <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xF000;" VerticalAlignment="Center" FontSize="20"/>
+            <TextBlock Text="Export notes" Margin="10 0" />
+        </StackPanel>
 
-        <Button Grid.Row="7" Grid.Column="0" Margin="3" Click="Button_Click">
-            <emoji:TextBlock Text="💾 Save"></emoji:TextBlock>
+        <Button Grid.Column="1" Grid.Row="4" Margin="3" Click="ExportButton_Click">
+            Export
         </Button>
+
+            <Button Grid.Row="6" Grid.Column="0" Margin="3" Click="Button_Click">
+            <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
+                <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE74E;" VerticalAlignment="Center" FontSize="20"/>
+                <TextBlock Text="Save" Margin="10 0" />
+            </StackPanel>
+        </Button>
+        
+
+
     </Grid>
 </Window>

--- a/Relanote.sln
+++ b/Relanote.sln
@@ -7,6 +7,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Core", "Core\Core.csproj", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FrontEnd", "FrontEnd\FrontEnd.csproj", "{8DBDCB5F-521C-424A-8559-6F6A5B4F8D71}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{007F68EA-1224-45CA-BD68-5BE7A7B95556}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core.Test", "Tests\Core.Test\Core.Test.csproj", "{337A0B0E-79ED-437B-8B0A-FCB18514E7C0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,11 +45,26 @@ Global
 		{8DBDCB5F-521C-424A-8559-6F6A5B4F8D71}.Release|x64.Build.0 = Release|Any CPU
 		{8DBDCB5F-521C-424A-8559-6F6A5B4F8D71}.Release|x86.ActiveCfg = Release|Any CPU
 		{8DBDCB5F-521C-424A-8559-6F6A5B4F8D71}.Release|x86.Build.0 = Release|Any CPU
+		{337A0B0E-79ED-437B-8B0A-FCB18514E7C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{337A0B0E-79ED-437B-8B0A-FCB18514E7C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{337A0B0E-79ED-437B-8B0A-FCB18514E7C0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{337A0B0E-79ED-437B-8B0A-FCB18514E7C0}.Debug|x64.Build.0 = Debug|Any CPU
+		{337A0B0E-79ED-437B-8B0A-FCB18514E7C0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{337A0B0E-79ED-437B-8B0A-FCB18514E7C0}.Debug|x86.Build.0 = Debug|Any CPU
+		{337A0B0E-79ED-437B-8B0A-FCB18514E7C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{337A0B0E-79ED-437B-8B0A-FCB18514E7C0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{337A0B0E-79ED-437B-8B0A-FCB18514E7C0}.Release|x64.ActiveCfg = Release|Any CPU
+		{337A0B0E-79ED-437B-8B0A-FCB18514E7C0}.Release|x64.Build.0 = Release|Any CPU
+		{337A0B0E-79ED-437B-8B0A-FCB18514E7C0}.Release|x86.ActiveCfg = Release|Any CPU
+		{337A0B0E-79ED-437B-8B0A-FCB18514E7C0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {73015210-0E26-43A5-B004-CA490332C005}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{337A0B0E-79ED-437B-8B0A-FCB18514E7C0} = {007F68EA-1224-45CA-BD68-5BE7A7B95556}
 	EndGlobalSection
 EndGlobal

--- a/Tests/Core.Test/Core.Test.csproj
+++ b/Tests/Core.Test/Core.Test.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Core.Test/ExtensionClasses/StringExtension.Test.cs
+++ b/Tests/Core.Test/ExtensionClasses/StringExtension.Test.cs
@@ -1,0 +1,15 @@
+using Core.ExtensionClasses;
+using NUnit.Framework;
+
+namespace Core.Test.ExtensionClasses
+{
+    public class StringExtension_Test
+    {
+        [TestCase("#", 6, "######")]
+        [TestCase("..", 3, "......")]
+        public void Test_Repeat_RepeatsCorrectAmount(string shouldRepeat, int times, string resultsIn)
+        {
+            Assert.AreEqual(resultsIn, shouldRepeat.Repeat(times), $"The string '{shouldRepeat}' was not repeated {times} times.");
+        }
+    }
+}

--- a/Tests/Core.Test/Objects/DocumentTypes/TxtDocument.Test.cs
+++ b/Tests/Core.Test/Objects/DocumentTypes/TxtDocument.Test.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Core.ExtensionClasses;
+using Core.Objects;
+using Core.Objects.DocumentTypes;
+using NUnit.Framework;
+
+namespace Core.Test.Objects.DocumentTypes
+{
+    public class TxtDocument_Test
+    {
+        TxtDocument doc;
+        Note note = null;
+        List<NoteTag> noteTags = null;
+
+        [SetUp]
+        public void SetUp()
+        {
+            note = new Note {Name = "My cool Note", Content = @"This is a note
+It is multiline.
+It contains some text
+Maybe even tags"};
+            noteTags = new List<Tag> {new Tag {Name = "Test Tag"}, new Tag {Name = "Other tag"}}
+                    .Select(tag => new NoteTag() {Note = note, Tag = tag}).ToList();
+            foreach(NoteTag noteTag in noteTags)
+            {
+                noteTag.Tag.NoteTags.Add(noteTag);
+            }
+            note.NoteTags = noteTags;
+            doc = new TxtDocument(new List<Note> {note});
+        }
+
+        [Test]
+        public void Test_ConvertTitle_ShouldConvertNote()
+        {
+            string expected = $"################{Environment.NewLine}# My cool Note #{Environment.NewLine}################{Environment.NewLine}";
+            string actual = doc.ConvertTitle(note.Name);
+
+            Assert.AreEqual(expected, actual, "The title was not converted correctly.");
+        }
+    }
+}

--- a/Tests/Core.Test/Objects/DocumentTypes/TxtDocument.Test.cs
+++ b/Tests/Core.Test/Objects/DocumentTypes/TxtDocument.Test.cs
@@ -1,3 +1,5 @@
+using System.Text;
+using System.IO;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -17,27 +19,80 @@ namespace Core.Test.Objects.DocumentTypes
         [SetUp]
         public void SetUp()
         {
-            note = new Note {Name = "My cool Note", Content = @"This is a note
+            note = new Note { Name = "My cool Note", Content = @"This is a note
 It is multiline.
 It contains some text
-Maybe even tags"};
-            noteTags = new List<Tag> {new Tag {Name = "Test Tag"}, new Tag {Name = "Other tag"}}
-                    .Select(tag => new NoteTag() {Note = note, Tag = tag}).ToList();
-            foreach(NoteTag noteTag in noteTags)
+Maybe even tags" };
+            noteTags = new List<Tag> { new Tag { Name = "Test Tag" }, new Tag { Name = "Other tag" } }
+                    .Select(tag => new NoteTag() { Note = note, Tag = tag }).ToList();
+            foreach (NoteTag noteTag in noteTags)
             {
                 noteTag.Tag.NoteTags.Add(noteTag);
             }
             note.NoteTags = noteTags;
-            doc = new TxtDocument(new List<Note> {note});
+            doc = new TxtDocument(new List<Note> { note });
         }
 
         [Test]
-        public void Test_ConvertTitle_ShouldConvertNote()
+        public void Test_ConvertTitle_ShouldConvertNoteTitle()
         {
             string expected = $"################{Environment.NewLine}# My cool Note #{Environment.NewLine}################{Environment.NewLine}";
             string actual = doc.ConvertTitle(note.Name);
 
             Assert.AreEqual(expected, actual, "The title was not converted correctly.");
+        }
+
+        [Test]
+        public void Test_ConvertTags_ShouldConvertNoteTags()
+        {
+            string expected = $"Tags: Test Tag, Other tag{Environment.NewLine.Repeat(3)}";
+            string actual = doc.ConvertTags(note.NoteTags);
+
+            Assert.AreEqual(expected, actual, "Tags were not converterd correctly.");
+        }
+
+        [Test]
+        public void Test_ConvertContent_ShouldConvertNoteContent()
+        {
+            string expected = $"Content:{Environment.NewLine}This is a note{Environment.NewLine}It is multiline.{Environment.NewLine}It contains some text{Environment.NewLine}Maybe even tags";
+            string actual = doc.ConvertContent(note.Content);
+
+            Assert.AreEqual(expected, actual, "Content was not converted correctly.");
+        }
+
+        [Test]
+        public void Test_ConvertNote_ShouldConvertEntireNote()
+        {
+            string expected = $"################{Environment.NewLine}# My cool Note #{Environment.NewLine}################{Environment.NewLine}";
+            expected += $"Tags: Test Tag, Other tag{Environment.NewLine.Repeat(3)}";
+            expected += $"Content:{Environment.NewLine}This is a note{Environment.NewLine}It is multiline.{Environment.NewLine}It contains some text{Environment.NewLine}Maybe even tags";
+
+            string actual = doc.ConvertNote(note);
+
+            Assert.AreEqual(expected, actual, "Note was not converted correctly.");
+        }
+
+        [Test]
+        public void Test_Export_WritesToStream()
+        {
+
+            string expected = $"################{Environment.NewLine}# My cool Note #{Environment.NewLine}################{Environment.NewLine}";
+            expected += $"Tags: Test Tag, Other tag{Environment.NewLine.Repeat(3)}";
+            expected += $"Content:{Environment.NewLine}This is a note{Environment.NewLine}It is multiline.{Environment.NewLine}It contains some text{Environment.NewLine}Maybe even tags";
+
+            using (MemoryStream memStream = new MemoryStream())
+            {
+                doc.Export(memStream);
+                using (MemoryStream clonedStream = new MemoryStream(memStream.ToArray()))
+                {
+                    byte[] bytes = new byte[clonedStream.Length];
+                    clonedStream.Read(bytes);
+                    string actual = Encoding.Default.GetString(bytes);
+                    Assert.AreEqual(expected, actual, "Export did not write the expected string");
+                }
+
+            }
+
         }
     }
 }

--- a/Tests/Core.Test/Objects/DocumentTypes/TxtDocument.Test.cs
+++ b/Tests/Core.Test/Objects/DocumentTypes/TxtDocument.Test.cs
@@ -54,7 +54,7 @@ Maybe even tags" };
         [Test]
         public void Test_ConvertContent_ShouldConvertNoteContent()
         {
-            string expected = $"Content:{Environment.NewLine}This is a note{Environment.NewLine}It is multiline.{Environment.NewLine}It contains some text{Environment.NewLine}Maybe even tags";
+            string expected = $"Content:{Environment.NewLine}This is a note{Environment.NewLine}It is multiline.{Environment.NewLine}It contains some text{Environment.NewLine}Maybe even tags{Environment.NewLine.Repeat(2)}";
             string actual = doc.ConvertContent(note.Content);
 
             Assert.AreEqual(expected, actual, "Content was not converted correctly.");
@@ -65,7 +65,7 @@ Maybe even tags" };
         {
             string expected = $"################{Environment.NewLine}# My cool Note #{Environment.NewLine}################{Environment.NewLine}";
             expected += $"Tags: Test Tag, Other tag{Environment.NewLine.Repeat(3)}";
-            expected += $"Content:{Environment.NewLine}This is a note{Environment.NewLine}It is multiline.{Environment.NewLine}It contains some text{Environment.NewLine}Maybe even tags";
+            expected += $"Content:{Environment.NewLine}This is a note{Environment.NewLine}It is multiline.{Environment.NewLine}It contains some text{Environment.NewLine}Maybe even tags{Environment.NewLine.Repeat(2)}";
 
             string actual = doc.ConvertNote(note);
 
@@ -78,7 +78,7 @@ Maybe even tags" };
 
             string expected = $"################{Environment.NewLine}# My cool Note #{Environment.NewLine}################{Environment.NewLine}";
             expected += $"Tags: Test Tag, Other tag{Environment.NewLine.Repeat(3)}";
-            expected += $"Content:{Environment.NewLine}This is a note{Environment.NewLine}It is multiline.{Environment.NewLine}It contains some text{Environment.NewLine}Maybe even tags";
+            expected += $"Content:{Environment.NewLine}This is a note{Environment.NewLine}It is multiline.{Environment.NewLine}It contains some text{Environment.NewLine}Maybe even tags{Environment.NewLine.Repeat(2)}";
 
             using (MemoryStream memStream = new MemoryStream())
             {


### PR DESCRIPTION
- Moved extension classes to their own namespace
- Added interface namespace with IDocument interface
- Added initial document types
- Added initial tests
- Initialised notetags list on object creation
- Moved string extension to its own class in the core.extensionclasses namespace
- Added test project to solution
- Added fileext, wrote export for txt
- Wrote appropriate tests
- Fixed content formatting
- Updated test for content formatting
- Made notes exportable
